### PR TITLE
cdc_uart: (workaround) fix enumeration after re-plug

### DIFF
--- a/cdc_uart.c
+++ b/cdc_uart.c
@@ -24,6 +24,7 @@
 
 #include <pico/stdlib.h>
 #include <pico/bootrom.h>
+#include <hardware/watchdog.h>
 #include <hardware/dma.h>
 #include <hardware/irq.h>
 #include "led.h"
@@ -303,6 +304,13 @@ void cdc_uart_task(void) {
         if (uart->is_connected) {
             handle_tx_buffer(uart);
         }
+    }
+}
+
+void tud_suspend_cb(bool remote_wakeup_en)
+{
+    if (!remote_wakeup_en) {
+        watchdog_reboot(0, 0, 0);
     }
 }
 

--- a/dirtyJtagConfig.h
+++ b/dirtyJtagConfig.h
@@ -42,7 +42,7 @@
 #define PIN_LED_RX     25
 
 #if ( USB_CDC_UART_BRIDGE )
-#define PIN_UART_INTF_COUNT 2
+#define PIN_UART_INTF_COUNT 1
 #define PIN_UART0 uart0
 #define PIN_UART0_TX    12
 #define PIN_UART0_RX    13

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -71,8 +71,6 @@ enum
 #if ( USB_CDC_UART_BRIDGE )
   ITF_NUM_CDC_1 = 1,
   ITF_NUM_CDC_1_DATA,
-  ITF_NUM_CDC_2 = 3,
-  ITF_NUM_CDC_2_DATA,
 #endif 
   ITF_NUM_TOTAL
 };
@@ -104,7 +102,6 @@ uint8_t const desc_configuration[CONFIG_TOTAL_LEN] =
 #if ( USB_CDC_UART_BRIDGE )
   // Interface 3 : Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_1, 4, CDC_NOTIF_EP1_NUM, 8, CDC_OUT_EP1_NUM, CDC_IN_EP1_NUM, 64),
-  TUD_CDC_DESCRIPTOR(ITF_NUM_CDC_2, 5, CDC_NOTIF_EP2_NUM, 8, CDC_OUT_EP2_NUM, CDC_IN_EP2_NUM, 64),
 #endif
 };
 
@@ -138,7 +135,6 @@ char const *string_desc_arr[] =
     usb_serial,                   // 3: Serial, uses flash unique ID
 #if ( USB_CDC_UART_BRIDGE )
     "Tiliqua CDC 0", // 4: CDC Interface 0
-    "Tiliqua CDC 1"  // 5: CDC Interface 1
 #endif
 };
 


### PR DESCRIPTION
- It seems TinyUSB will sometimes incorrectly respond to a SET_CONFIGURATION request when the device is unplugged- and re-plugged, which causes it to fail enumeration sometimes on a re-plug.
- As a workaround, issue an RP2040 watchdog reset whenever the debugger is unplugged, ensuring TinyUSB and all state machines are in a clean state as soon as Tiliqua is plugged in again.
- bonus: remove CDC1 as only CDC0 is electrically connected anyway.