### PR TITLE
apfbug: pull upstream bugfixes, fix autosuspend disconnects

### DIFF
--- a/cdc_uart.c
+++ b/cdc_uart.c
@@ -64,6 +64,8 @@ static size_t code_index = 0;
 static bool next_is_cmd = false;
 uint32_t reconfigure = 0;
 
+static bool global_suspended = false;
+
 static uint n_bits(uint n)
 {
 	int i;
@@ -305,13 +307,16 @@ void cdc_uart_task(void) {
             handle_tx_buffer(uart);
         }
     }
+
+    if (global_suspended && (gpio_get(PIN_VBUS) == false)) {
+        // Disconnect!
+        watchdog_reboot(0, 0, 0);
+    }
 }
 
 void tud_suspend_cb(bool remote_wakeup_en)
 {
-    if (!remote_wakeup_en) {
-        watchdog_reboot(0, 0, 0);
-    }
+    global_suspended = !remote_wakeup_en;
 }
 
 void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const* line_coding)

--- a/dirtyJtag.c
+++ b/dirtyJtag.c
@@ -153,6 +153,9 @@ int main()
     usb_serial_init();
     tusb_init();
 
+    gpio_init(PIN_VBUS);
+    gpio_set_dir(PIN_VBUS, GPIO_IN);
+
     led_init( LED_INVERTED, PIN_LED_TX, PIN_LED_RX, PIN_LED_ERROR );
 #if ( USB_CDC_UART_BRIDGE )
     cdc_uart_init( PIN_UART0, PIN_UART0_RX, PIN_UART0_TX );

--- a/dirtyJtagConfig.h
+++ b/dirtyJtagConfig.h
@@ -27,7 +27,10 @@
 // RST  GPIO
 // TRST GPIO
 
+#define PIN_VBUS 22 
+
 #if ( BOARD_TYPE == BOARD_PICO )
+
 
 #define PIN_TDI 16 
 #define PIN_TDO 17

--- a/jtag.pio
+++ b/jtag.pio
@@ -16,8 +16,9 @@
     pull                        ; get length-1 and disregard previous OSR state 
     out x, 32       side 0      ; this moves the first 32 bits into X
 loop:
-    out pins, 1     side 0      ; Stall here on empty (sideset proceeds even if instruction stalls, so we stall with SCK low
-    in pins, 1      side 1 [1] 
+    out pins, 1     side 0      ; Stall here on empty (sideset proceeds even if instruction stalls, so we stall with TCK low
+    nop             side 1      ; raise TCK
+    in pins, 1      side 1      ; sample TDO
     jmp x-- loop    side 0
     push            side 0      ; Force the last ISR bits to be pushed to the tx fifo
 % c-sdk {

--- a/pio_jtag.c
+++ b/pio_jtag.c
@@ -298,7 +298,10 @@ void jtag_transfer(const pio_jtag_inst_t *jtag, uint32_t length, const uint8_t* 
 
 uint8_t jtag_strobe(const pio_jtag_inst_t *jtag, uint32_t length, bool tms, bool tdi)
 {
-    return pio_jtag_write_tms_blocking(jtag, tdi, tms, length);
+    if (length == 0)
+        return jtag_get_tdo(jtag) ? 0xFF : 0x00;
+    else
+        return pio_jtag_write_tms_blocking(jtag, tdi, tms, length);
 }
 
 

--- a/pio_jtag.c
+++ b/pio_jtag.c
@@ -7,6 +7,8 @@ void jtag_task();//to process USB OUT packets while waiting for DMA to finish
 
 #define DMA
 
+static bool last_tdo = false;
+
 #if 0
 static bool pins_source = false; //false: PIO, true: GPIO
 
@@ -129,6 +131,7 @@ void __time_critical_func(pio_jtag_write_blocking)(const pio_jtag_inst_t *jtag, 
             }
         }
     }
+    last_tdo = !!(x & 1);
 }
 
 void __time_critical_func(pio_jtag_write_read_blocking)(const pio_jtag_inst_t *jtag, const uint8_t *bsrc, uint8_t *bdst,
@@ -177,8 +180,9 @@ void __time_critical_func(pio_jtag_write_read_blocking)(const pio_jtag_inst_t *j
             }
         }
     }
-    //fix the last byte
-    if (last_shift) 
+    last_tdo = !!(*rx_last_byte_p & 1);
+    // fix the last byte
+    if (last_shift)
     {
         *rx_last_byte_p = *rx_last_byte_p << last_shift;
     }
@@ -231,12 +235,8 @@ uint8_t __time_critical_func(pio_jtag_write_tms_blocking)(const pio_jtag_inst_t 
             }
         }
     }
-    //fix the last byte
-    if (last_shift)
-    {
-        x = x << last_shift;
-    }
-    return x;
+    last_tdo = !!(x & 1);
+    return last_tdo ? 0xFF : 0x00;
 }
 
 static void init_pins(uint pin_tck, uint pin_tdi, uint pin_tdo, uint pin_tms, uint pin_rst, uint pin_trst)
@@ -322,7 +322,7 @@ void jtag_set_clk(const pio_jtag_inst_t *jtag, bool value)
 
 bool jtag_get_tdo(const pio_jtag_inst_t *jtag)
 {
-    return !! toggle_bits_in_buffer[0];
+    return last_tdo;
 }
 
 


### PR DESCRIPTION
- TinyUSB has an undesirable bug where on RP2040 it always assumes VBUS is connected. This is fine for bus-powered devices, but Tiliqua is not, so we need a way of detecting true disconnects.
- As a workaround, we keep track of whether the device is suspended or not. If we are suspended AND the VBUS GPIO falls low, then we kick the watchdog to workaround the existing multi-enumeration bug (which is yet another bug in TinyUSB I suspect).
- This works because TinyUSB fires the 'suspended' handler if the device is disconnected (technically this is not 'suspended' as I understand it from the USB standard)
- While we're at it, pull in some recent changes from `pico-dirtyJtag`.

Fixes https://github.com/apfaudio/apfbug/issues/7